### PR TITLE
Fix spelling errors in POD and README

### DIFF
--- a/README
+++ b/README
@@ -61,7 +61,7 @@ DESCRIPTION
 
     All API requests are done using Furl module. For more accurate timeouts
     Net::DNS::Lite is used, as described in Furl::HTTP. Furl settings can be
-    overriden using "furlopts".
+    overridden using "furlopts".
 
 METHODS
   new
@@ -131,7 +131,7 @@ FUNCTIONS
     fields described in Dropbox API docs
     <https://www.dropbox.com/developers/core/docs#metadata>. $path defaults
     to "/". If there is unfinished chunked upload on handle, it will be
-    commited.
+    committed.
 
         foreach my $file (contents($dropbox, '/data')) {
             next if $file->{'is_dir'};
@@ -158,7 +158,7 @@ FUNCTIONS
     Function is useful for uploading small files (up to 150MB possible) in
     one request (at least two API requests required for chunked upload, used
     in open-write-close sequence). If there is unfinished chunked upload on
-    handle, it will be commited.
+    handle, it will be committed.
 
         local $/;
         open my $data, '<', '2012.dat' or die $!;

--- a/lib/File/Dropbox.pm
+++ b/lib/File/Dropbox.pm
@@ -633,7 +633,7 @@ L<sysread|perlfunc/sysread>, L<getc|perlfunc/getc>, L<eof|perlfunc/eof>. For wri
 L<syswrite|perlfunc/syswrite>, L<print|perlfunc/print>, L<printf|perlfunc/printf>, L<say|perlfunc/say>.
 
 All API requests are done using L<Furl> module. For more accurate timeouts L<Net::DNS::Lite> is used, as described in L<Furl::HTTP>. Furl settings
-can be overriden using C<furlopts>.
+can be overridden using C<furlopts>.
 
 =head1 METHODS
 
@@ -714,7 +714,7 @@ Arguments: $dropbox [, $path]
 
 Function returns list of hashrefs representing directory content. Hash fields described in L<Dropbox API
 docs|https://www.dropbox.com/developers/core/docs#metadata>. C<$path> defaults to C</>. If there is
-unfinished chunked upload on handle, it will be commited.
+unfinished chunked upload on handle, it will be committed.
 
     foreach my $file (contents($dropbox, '/data')) {
         next if $file->{'is_dir'};
@@ -742,7 +742,7 @@ Arguments: $dropbox, $path, $data
 
 Function is useful for uploading small files (up to 150MB possible) in one request (at least
 two API requests required for chunked upload, used in open-write-close sequence). If there is
-unfinished chunked upload on handle, it will be commited.
+unfinished chunked upload on handle, it will be committed.
 
     local $/;
     open my $data, '<', '2012.dat' or die $!;


### PR DESCRIPTION

In Debian we are currently applying the following patch to
File-Dropbox.
We thought you might be interested in it too.

    Description: Fix spelling errors in POD and README
    Author: Alex Muntada <alexm@alexm.org>

The patch is tracked in our Git repository at
https://anonscm.debian.org/cgit/pkg-perl/packages/libfile-dropbox-perl.git/plain/debian/patches/spelling-error-in-manpage.patch

Thanks for considering,
  Alex Muntada,
  Debian Perl Group
